### PR TITLE
style: add quotation marks to vendor and device

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -3667,11 +3667,12 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 
 		if (verblevel > 0)
 			printf("\n");
-		printf("Bus %03u Device %03u: ID %04x:%04x %s %s\n",
+		printf("Bus %03u Device %03u: ID %04x:%04x \"%s\" \"%s\"\n",
 				bnum, dnum,
 				desc.idVendor,
 				desc.idProduct,
 				vendor, product);
+
 		if (verblevel > 0)
 			dumpdev(dev);
 	}


### PR DESCRIPTION
## Description

Before:

It is confusing to use whitespace as the separator between USB `vendor` and `product`.

```shell
$ lsusb
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 002 Device 003: ID 0e0f:0002 VMware, Inc. Virtual USB Hub
Bus 002 Device 002: ID 0e0f:0003 VMware, Inc. Virtual Mouse
Bus 002 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub
```

After:


It greatly simplifies the extraction of command output strings. If developers want to extract the `vendor` and `product` fields, then the `""` will be used as a separator.

```shell
$ lsusb
Bus 001 Device 001: ID 1d6b:0002 "Linux Foundation" "2.0 root hub"
Bus 002 Device 003: ID 0e0f:0002 "VMware, Inc." "Virtual USB Hub"
Bus 002 Device 002: ID 0e0f:0003 "VMware, Inc." "Virtual Mouse"
Bus 002 Device 001: ID 1d6b:0001 "Linux Foundation" "1.1 root hub"
```
